### PR TITLE
Crafting recipes, math libraries, and parametric forces

### DIFF
--- a/DredgeTagsAndRecipes/data/minecraft/recipes/cherry_planks_from_cherry_wood.json
+++ b/DredgeTagsAndRecipes/data/minecraft/recipes/cherry_planks_from_cherry_wood.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "item": "vinery:cherry_wood"
+      }
+    ],
+    "result": {
+      "item": "vinery:cherry_planks"
+    }
+  }

--- a/DredgeTagsAndRecipes/data/minecraft/recipes/obsidian_minifridge.json
+++ b/DredgeTagsAndRecipes/data/minecraft/recipes/obsidian_minifridge.json
@@ -1,0 +1,14 @@
+{
+  "type": "beachparty:mini_fridge_mixing",
+  "ingredients": [
+    {
+      "item": "minecraft:lava_bucket"
+    },
+    {
+      "item": "minecraft:ice"
+    }
+  ],
+  "result": {
+    "item": "minecraft:obsidian"
+  }
+}

--- a/DredgeTagsAndRecipes/data/minecraft/recipes/warped_planks_from_warped_wood.json
+++ b/DredgeTagsAndRecipes/data/minecraft/recipes/warped_planks_from_warped_wood.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "item": "architects_palette:warped_wood"
+      }
+    ],
+    "result": {
+      "item": "architects_palette:warped_planks"
+    }
+  }

--- a/DredgeTagsAndRecipes/data/minecraft/recipes/warping/crying_obsidian_from_obsidian_warping.json
+++ b/DredgeTagsAndRecipes/data/minecraft/recipes/warping/crying_obsidian_from_obsidian_warping.json
@@ -1,0 +1,12 @@
+{
+    "type": "architects_palette:warping",
+    "dimension": "minecraft:the_nether",
+    "ingredient": [
+        {
+            "item": "minecraft:obsidian"
+        }
+    ],
+    "result": {
+        "item": "minecraft:crying_obsidian"
+    }
+}

--- a/DredgeTagsAndRecipes/data/minecraft/tags/blocks/soul_speed_blocks.json
+++ b/DredgeTagsAndRecipes/data/minecraft/tags/blocks/soul_speed_blocks.json
@@ -1,0 +1,10 @@
+{
+    "replace": false,
+    "values": [
+        "consistency_plus:cobbled_soul_sandstone",
+        "consistency_plus:cobbled_soul_sandstone_slab",
+        "consistency_plus:cobbled_soul_sandstone_stairs",
+        "consistency_plus:cobbled_soul_sandstone_wall",
+        "consistency_plus:cobbled_soul_sandstone_gate"
+    ]
+}

--- a/katy-origins/LICENSE
+++ b/katy-origins/LICENSE
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright 2024 corviraptor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/katy-origins/README.md
+++ b/katy-origins/README.md
@@ -1,0 +1,45 @@
+# katy_origins
+
+minecraft origins datapack!!
+
+## Dependencies
+
+[nn_math](https://github.com/NOPEname/nn_math) by NOPEname
+
+## katyorigins/powers
+
+### wishdir.json
+
+Tracks the direction the player wants to move and stores that in scoreboard variables `@s wishdir_x` and `@s wishdir_z`. These values are scaled by 10000 for decimal precision and the vector `<@s wishdir_x, @s wishdir_z>` is the player's input direction in world space.
+
+### track_velocity.json
+
+Tracks the velocity vector of the entity and stores that in scoreboard variables `@s velocity_x`, `@s velocity_y` and `@s velocity_z`. These values are scaled by 10000 for decimal precision.
+
+## katymath/functions
+
+### 2d_matrix_rotation.mcfunction
+
+Does a 2D matrix rotation. Depends on nnmath/functions/trig.
+
+Before calling the function, set the inputs:
+
+`rotation_angle matrices`: Angle to rotate vector basis by
+
+`in_x matrices`: Vector's X component
+
+`in_y matrices`: Vector's Y component
+
+## katyforces/functions
+
+### add_force.mcfunction
+
+Adds a force to the target entity using recursive calls to `/motion` until the desired force on each axis is reached. This allows us to use scoreboard variables
+ to affect motion rather than literals. Currently only supports X and Z axis motion, although Y axis motion would be trivial to implement. There is a limit to
+  the amount of iterations allowed meaning greater forces may not work properly for now.
+
+Before calling the function, set the inputs:
+
+`in_x forces`: Force X component
+
+`in_Z forces`: Force Z component

--- a/katy-origins/data/katyforces/functions/add_force.mcfunction
+++ b/katy-origins/data/katyforces/functions/add_force.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set iterations forces 0
+
+function katyforces:add_force_recursive

--- a/katy-origins/data/katyforces/functions/add_force_recursive.mcfunction
+++ b/katy-origins/data/katyforces/functions/add_force_recursive.mcfunction
@@ -1,0 +1,15 @@
+execute as @s if score in_x forces > approx_zero constants run motion add @s 0.01 0 0
+execute as @s if score in_x forces > approx_zero constants run scoreboard players operation in_x forces -= one_hundredth constants
+
+execute as @s if score in_x forces < approx_negative_zero constants run motion add @s -0.01 0 0
+execute as @s if score in_x forces < approx_negative_zero constants run scoreboard players operation in_x forces += one_hundredth constants
+
+execute as @s if score in_z forces > approx_zero constants run motion add @s 0 0 0.01
+execute as @s if score in_z forces > approx_zero constants run scoreboard players operation in_z forces -= one_hundredth constants
+
+execute as @s if score in_z forces < approx_negative_zero constants run motion add @s -0 0 -0.01
+execute as @s if score in_z forces < approx_negative_zero constants run scoreboard players operation in_z forces += one_hundredth constants
+
+scoreboard players add iterations forces 1
+
+execute as @s if score iterations forces < max_iterations constants run function katyforces:add_force_recursive

--- a/katy-origins/data/katyforces/functions/init.mcfunction
+++ b/katy-origins/data/katyforces/functions/init.mcfunction
@@ -1,0 +1,9 @@
+scoreboard objectives add forces dummy
+
+scoreboard objectives add constants dummy
+scoreboard players set max_iterations constants 25
+scoreboard players set approx_zero constants 100
+scoreboard players set approx_negative_zero constants -100
+scoreboard players set one_hundredth constants 100
+
+tellraw @a "katyforces has been loaded!"

--- a/katy-origins/data/katymath/functions/2d_matrix_rotation.mcfunction
+++ b/katy-origins/data/katymath/functions/2d_matrix_rotation.mcfunction
@@ -1,0 +1,58 @@
+# matrix multiplication to rotate basis. i ♥ math
+# wiki article:             https://en.wikipedia.org/wiki/Rotation_matrix 
+# visualization/calculator: http://matrixmultiplication.xyz/
+
+# the expression we want to evaluate...
+# [ cos(yaw) -sin(yaw) ][ x ]
+# [ sin(yaw)  cos(yaw) ][ y ]
+
+# ...boils down to this after matrix multiplication:
+# x = [ x * cos_yaw - y * sin_yaw ] 
+# y = [ x * sin_yaw + y * cos_yaw ]
+
+# this trig stuff should be the only expensive operation besides maybe the above nbt query, 
+# everything else doesnt invoke any divisions or square roots or anything
+
+# our input
+scoreboard players operation in nnmath_trig = rotation_angle matrices
+
+# we use cos_bs and sin_bs because it uses the same fixed point scale as we do, 10,000
+
+# cos(yaw)
+function nnmath:trig/cos_bs/exe 
+scoreboard players operation cos_yaw matrices = out nnmath_trig 
+
+# sin(yaw)
+function nnmath:trig/sin_bs/exe
+scoreboard players operation sin_yaw matrices = out nnmath_trig 
+
+# prepare our memory addresses
+scoreboard players operation x_cos_yaw matrices = cos_yaw matrices
+scoreboard players operation z_sin_yaw matrices = sin_yaw matrices
+
+scoreboard players operation x_sin_yaw matrices = sin_yaw matrices
+scoreboard players operation z_cos_yaw matrices = cos_yaw matrices
+
+# build our terms
+# (x * cos_yaw)
+scoreboard players operation x_cos_yaw matrices *= in_x matrices
+# (y * sin_yaw)
+scoreboard players operation z_sin_yaw matrices *= in_y matrices
+
+# (x * sin_yaw)
+scoreboard players operation x_sin_yaw matrices *= in_x matrices
+# (y * cos_yaw)
+scoreboard players operation z_cos_yaw matrices *= in_y matrices
+
+# out_x = [ (x * cos_yaw) - (y * sin_yaw) ] 
+#       = [    x_cos_yaw  -   z_sin_yaw   ] 
+scoreboard players operation out_x matrices = x_cos_yaw matrices
+scoreboard players operation out_x matrices -= z_sin_yaw matrices
+
+# out_y = [ (x * sin_yaw) + (y * cos_yaw) ]
+#       = [   x_sin_yaw   +   z_cos_yaw   ]
+scoreboard players operation out_y matrices = x_sin_yaw matrices
+scoreboard players operation out_y matrices += z_cos_yaw matrices
+
+# out is hopefully now rotated from in by the rotation_angle
+# now you can pick up anything

--- a/katy-origins/data/katymath/functions/init.mcfunction
+++ b/katy-origins/data/katymath/functions/init.mcfunction
@@ -1,0 +1,8 @@
+scoreboard objectives add constants dummy
+scoreboard players set fixed_point_scale constants 10000
+scoreboard players set zero constants 0
+scoreboard objectives add temp_variables dummy
+
+scoreboard objectives add matrices dummy
+
+tellraw @a "katymath has been loaded!"

--- a/katy-origins/data/katyorigins/functions/init.mcfunction
+++ b/katy-origins/data/katyorigins/functions/init.mcfunction
@@ -1,0 +1,4 @@
+function katyorigins:movement/init
+function katyorigins:combat/init
+
+tellraw @a "katyorigins has been loaded!"

--- a/katy-origins/data/katyorigins/functions/katycombat/init.mcfunction
+++ b/katy-origins/data/katyorigins/functions/katycombat/init.mcfunction
@@ -1,0 +1,5 @@
+scoreboard objectives add attack_anticipation dummy
+scoreboard objectives add attack_length dummy
+scoreboard objectives add parriable dummy
+
+scoreboard objectives add debug dummy

--- a/katy-origins/data/katyorigins/functions/movement/calc_velocity.mcfunction
+++ b/katy-origins/data/katyorigins/functions/movement/calc_velocity.mcfunction
@@ -1,0 +1,22 @@
+# calc horizontal velocity vector
+execute as @s store result score current_x temp_variables run data get entity @s Pos[0] 10000
+scoreboard players operation @s velocity_x = current_x temp_variables
+scoreboard players operation @s velocity_x -= @s last_pos_x
+scoreboard players operation @s last_pos_x = current_x temp_variables
+
+execute as @s store result score current_z temp_variables run data get entity @s Pos[2] 10000
+scoreboard players operation @s velocity_z = current_z temp_variables
+scoreboard players operation @s velocity_z -= @s last_pos_z
+scoreboard players operation @s last_pos_z = current_z temp_variables
+
+execute as @s store result score current_y temp_variables run data get entity @s Pos[1] 10000
+scoreboard players operation @s velocity_y = current_y temp_variables
+scoreboard players operation @s velocity_y -= @s last_pos_y
+scoreboard players operation @s last_pos_y = current_y temp_variables
+
+# calc and store vector magnitude
+scoreboard players operation in0.x nnmath_vec = @s velocity_x
+scoreboard players operation in0.y nnmath_vec = @s velocity_z
+
+function nnmath:vec/2/get_length/exe
+scoreboard players operation @s xz_speed = out nnmath_vec

--- a/katy-origins/data/katyorigins/functions/movement/init.mcfunction
+++ b/katy-origins/data/katyorigins/functions/movement/init.mcfunction
@@ -1,0 +1,21 @@
+scoreboard objectives add velocity_x dummy
+scoreboard objectives add velocity_y dummy
+scoreboard objectives add velocity_z dummy
+
+scoreboard objectives add stored_velocity_x dummy
+scoreboard objectives add stored_velocity_y dummy
+scoreboard objectives add stored_velocity_z dummy
+
+scoreboard objectives add last_stored_velocity_x dummy
+scoreboard objectives add last_stored_velocity_y dummy
+scoreboard objectives add last_stored_velocity_z dummy
+
+
+scoreboard objectives add last_pos_x dummy
+scoreboard objectives add last_pos_y dummy
+scoreboard objectives add last_pos_z dummy
+
+scoreboard objectives add xz_speed dummy
+
+scoreboard objectives add wishdir_x dummy
+scoreboard objectives add wishdir_z dummy

--- a/katy-origins/data/katyorigins/functions/movement/store_velocity.mcfunction
+++ b/katy-origins/data/katyorigins/functions/movement/store_velocity.mcfunction
@@ -1,0 +1,7 @@
+scoreboard players operation @s last_stored_velocity_x = @s stored_velocity_x 
+scoreboard players operation @s last_stored_velocity_y = @s velocity_y
+scoreboard players operation @s last_stored_velocity_z = @s stored_velocity_z
+
+scoreboard players operation @s stored_velocity_x = @s velocity_x 
+scoreboard players operation @s stored_velocity_y = @s velocity_y
+scoreboard players operation @s stored_velocity_z = @s velocity_z

--- a/katy-origins/data/katyorigins/functions/movement/wishdir_to_world_space.mcfunction
+++ b/katy-origins/data/katyorigins/functions/movement/wishdir_to_world_space.mcfunction
@@ -1,0 +1,13 @@
+# get the player's angle of rotation (in degrees, scaled by 100)
+execute as @s store result score rotation_angle matrices run data get entity @s Rotation[0] 100
+execute as @s store result score in_x matrices run resource get @s katyorigins:wishdir_wishx
+execute as @s store result score in_y matrices run resource get @s katyorigins:wishdir_wishz
+
+# normalization hack we can get away with because we dont have analog inputs, 0.707 is approx. equal to (1 / √2)
+execute if score @s in_y > zero constants run scoreboard players operation @s in_x *= 0.707
+execute if score @s in_x > zero constants run scoreboard players operation @s in_y *= 0.707
+
+function katymath:2d_matrix_rotation
+
+scoreboard players operation @s wishdir_x = out_x matrices
+scoreboard players operation @s wishdir_z = out_y matrices

--- a/katy-origins/data/katyorigins/origins/katycombat.json
+++ b/katy-origins/data/katyorigins/origins/katycombat.json
@@ -1,0 +1,7 @@
+{
+  "powers": [
+      "katyorigins:combat/anticipate_attack",
+      "katyorigins:comboblade/sword_draw"
+  ]
+}
+

--- a/katy-origins/data/katyorigins/powers/combat/anticipate_attack.json
+++ b/katy-origins/data/katyorigins/powers/combat/anticipate_attack.json
@@ -1,0 +1,41 @@
+{
+    "type": "origins:multiple",
+    "timer": {
+        "type": "origins:resource",
+        "min": 0,
+        "max": 20
+    },
+    "tick_timer": {
+        "type": "origins:action_over_time",
+        "interval": 1,
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:combat/anticipate_attack_timer",
+            "change": 1,
+            "operation": "add"
+        },
+        "falling_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:combat/anticipate_attack_timer",
+            "change": 0,
+            "operation": "set"
+        },
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:resource",
+                    "resource": "katyorigins:combat/anticipate_attack_timer",
+                    "comparison": "!=",
+                    "compare_to": 0
+                },
+                {
+                    "type": "origins:resource",
+                    "resource": "katyorigins:combat/anticipate_attack_timer",
+                    "comparison": "!=",
+                    "compare_to": 20
+                }
+            ]
+        }
+    }
+}

--- a/katy-origins/data/katyorigins/powers/comboblade/sword_draw.json
+++ b/katy-origins/data/katyorigins/powers/comboblade/sword_draw.json
@@ -1,0 +1,90 @@
+{
+    "type": "origins:multiple",
+    "start_timer": {
+        "type": "origins:active_self",
+        "key": "key.use",
+        "entity_action": {
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:change_resource",
+                    "resource": "katyorigins:combat/anticipate_attack_timer",
+                    "change": 10,
+                    "operation": "set"
+                }
+            ]
+        },
+        "condition": {
+            "type": "origins:resource",
+            "resource": "katyorigins:combat/anticipate_attack_timer",
+            "compare_to": 0,
+            "comparison": "=="
+        }
+    },
+    "actions": {
+        "type": "origins:action_over_time",
+        "rising_action": {
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:spawn_particles",
+                    "particle": {
+                        "type": "minecraft:soul_fire_flame"
+                    },
+                    "count": 10,
+                    "speed": 1.0,
+                    "force": true,
+                    "spread": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    }
+                },
+                {
+                    "type": "origins:play_sound",
+                    "sound": "minecraft:item.axe.scrape",
+                    "volume": 1.2,
+                    "pitch": 1.6
+                }
+            ]
+        },
+        "falling_action": {
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:spawn_particles",
+                    "particle": {
+                        "type": "minecraft:angry_villager"
+                    },
+                    "count": 10,
+                    "speed": 1.0,
+                    "force": true,
+                    "spread": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                {
+                    "type": "origins:play_sound",
+                    "sound": "minecraft:entity.drowned.shoot",
+                    "volume": 1.2,
+                    "pitch": 1
+                },
+                {
+                    "type": "origins:play_sound",
+                    "sound": "minecraft:entity.goat.ram_impact",
+                    "volume": 0.7,
+                    "pitch": 1
+                }
+            ]
+        },
+
+        "condition": {
+            "type": "origins:resource",
+            "resource": "katyorigins:combat/anticipate_attack_timer",
+            "compare_to": 0,
+            "comparison": "!="
+        }
+    }
+}

--- a/katy-origins/data/katyorigins/powers/track_velocity.json
+++ b/katy-origins/data/katyorigins/powers/track_velocity.json
@@ -1,0 +1,12 @@
+{
+    "type": "origins:action_over_time",
+    "entity_action": {
+        "type": "origins:execute_command",
+        "command": "function katyorigins:calc_velocity"
+    },
+    "condition": {
+        "type": "origins:creative_flying",
+        "inverted": true
+    },
+    "interval": 2
+}

--- a/katy-origins/data/katyorigins/powers/wishdir.json
+++ b/katy-origins/data/katyorigins/powers/wishdir.json
@@ -1,0 +1,151 @@
+{
+    "type": "origins:multiple",
+    "hidden": true,
+
+    "wishx": {
+        "type": "origins:resource",
+        "min": -1,
+        "max": 1,
+        "hud_render": {
+            "should_render": true
+        }
+    },
+
+    "wishz": {
+        "type": "origins:resource",
+        "min": -1,
+        "max": 1,
+        "hud_render": {
+            "should_render": true
+        }
+    },
+
+    "forward": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishz",
+            "operation": "set",
+            "change": 1
+        },
+        "key": {
+            "key": "key.forward",
+            "continuous": true
+        }
+    },
+
+    "back": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishz",
+            "operation": "set",
+            "change": -1
+        },
+        "key": {
+            "key": "key.back",
+            "continuous": true
+        }
+    },
+
+    "right": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishx",
+            "operation": "set",
+            "change": -1
+        },
+        "key": {
+            "key": "key.right",
+            "continuous": true
+        }
+    },
+
+    "left": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishx",
+            "operation": "set",
+            "change": 1
+        },
+        "key": {
+            "key": "key.left",
+            "continuous": true
+        }
+    },
+
+    "no_x": {
+        "type": "origins:action_over_time",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishx",
+            "operation": "set",
+            "change": 0
+        },
+        "interval": 1,
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "apugli:key_pressed",
+                    "key": {
+                        "key": "key.right",
+                        "continuous": true
+                    },
+                    "inverted": true
+                },
+                {
+                    "type": "apugli:key_pressed",
+                    "key": {
+                        "key": "key.left",
+                        "continuous": true
+                    },
+                    "inverted": true
+                }
+            ]
+        }
+    },
+
+    "no_z": {
+        "type": "origins:action_over_time",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "katyorigins:wishdir_wishz",
+            "operation": "set",
+            "change": 0
+        },
+        "interval": 1,
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "apugli:key_pressed",
+                    "key": {
+                        "key": "key.forward",
+                        "continuous": true
+                    },
+                    "inverted": true
+                },
+                {
+                    "type": "apugli:key_pressed",
+                    "key": {
+                        "key": "key.back",
+                        "continuous": true
+                    },
+                    "inverted": true
+                }
+            ]
+        }
+    },
+
+    "wishdir_to_world_space": {
+        "type": "origins:action_over_time",
+        "entity_action": {
+            "type": "origins:execute_command",
+            "command": "function katyorigins:wishdir_to_world_space"
+        },
+        "interval": 1
+    }   
+}

--- a/katy-origins/data/minecraft/tags/functions/load.json
+++ b/katy-origins/data/minecraft/tags/functions/load.json
@@ -1,0 +1,7 @@
+{
+	"values":[
+		"katymath:init",
+		"katyforces:init",
+		"katyorigins:init"
+	]
+}

--- a/katy-origins/data/origins/origin_layers/katycombat.json
+++ b/katy-origins/data/origins/origin_layers/katycombat.json
@@ -1,0 +1,7 @@
+{
+    "origins": [
+        "katyorigins:katycombat"
+    ],
+    "auto_choose": true,
+    "hidden": true
+}

--- a/katy-origins/pack.mcmeta
+++ b/katy-origins/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 10,
+    "description": "Kathrynne's Origins and Tweaks for DredgeSMP"
+  }
+}

--- a/nn_math/LICENSE
+++ b/nn_math/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 NOPEname
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nn_math/README.md
+++ b/nn_math/README.md
@@ -1,0 +1,38 @@
+# Minecraft Math Functions
+This is a library of math related functions for your Minecraft project.
+Supported Minecraft versions: 1.15, 1.16 (some functions might also work in 1.14 - no warranty!)
+
+
+## License
+MIT license (https://choosealicense.com/licenses/mit/)
+
+Short summary:
+1) Do whatevery you want with my code
+2) Condition: Preserve the copyright notice containing my name ("NOPEname") attached to my code in your project (can be found inside the "LICENSE" file)
+3) Warranty: absolutely zero! My code doesn't do what you want it to do or even breaks something? Sorry, but... no warranty!
+
+
+## Setup
+This project can be used as one, all-including datapack.
+However you can as well take parts (subfolders and/or single function files) from it to include them directly in your own datapacks. In that case you have to take care yourself for that it works as intended.
+
+
+## Structure
+The library contains a bunch of different modules, which are separated in subfolders.
+Run `/function math:list` in chat to get a list of all installed modules (might not work if you don't use the full/original datapack).
+Run `/function math:help` or `/function math:<module/function name>/help` to get more information about how to use this module/function (input-/output-behavior).
+
+Modules can be initialized using `/function math:<module name>/setup`, in case it does not happen automatically. `/function math:setup` will call the setup functions of all modules at once.
+
+Functions in `private` subfolders are used by the interface functions. Do not call them directly.
+
+
+## How to use
+Most modules will works as follows:
+1) Set input values as described in `<module/function name>\help.mcfunction`
+2) Execute `/function math:<module name>/exe`
+3) Access output values as described `<module/function name>\help.mcfunction`
+
+
+## Found Bugs / Need Help?
+Contact me (NOPEname) on any platform you like (Twitter, PlanetMinecraft, Discord, etc.)

--- a/nn_math/data/minecraft/tags/functions/load.json
+++ b/nn_math/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+	"values":[
+		"nnmath:setup"
+	]
+}

--- a/nn_math/data/nnmath/functions/help - preset.txt
+++ b/nn_math/data/nnmath/functions/help - preset.txt
@@ -1,0 +1,11 @@
+ ##by NOPEname
+
+tellraw @a {"text":"\n>>Help > sqrt:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: ","color":"gray"}
+tellraw @a {"text":"-Preserves input:","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: ","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy:","color":"gray"}
+tellraw @a {"text":"-Method used:","color":"gray"}

--- a/nn_math/data/nnmath/functions/help.mcfunction
+++ b/nn_math/data/nnmath/functions/help.mcfunction
@@ -1,0 +1,10 @@
+##by NOPEname
+
+tellraw @a {"text":"\n-------------------------------------","color":"gold"}
+tellraw @a {"text":">>Help:","color":"gold"}
+tellraw @a {"text":"-Run '/function nnmath:<module>/help' for information about this module","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:<module>/<function>/help' for information about this function","color":"gray"}
+tellraw @a {"text":"-'../<function>/help' will tell you how to use this function (input-/output-behaviour, etc.)","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:list' to get a list of all installed modules(/functions)","color":"gray"}
+tellraw @a {"text":"-Still have questions? Contact NOPEname (on Twitter, Discord, Youtube, etc.)!","color":"gray"}
+tellraw @a {"text":"-------------------------------------","color":"gold"}

--- a/nn_math/data/nnmath/functions/list.mcfunction
+++ b/nn_math/data/nnmath/functions/list.mcfunction
@@ -1,0 +1,12 @@
+##by NOPEname
+
+tellraw @a {"text":"\n-------------------------------------","color":"gold"}
+tellraw @a {"text":">>Listing installed modules:","color":"gold"}
+
+function nnmath:sqrt/list
+function nnmath:trig/list
+function nnmath:vec/list
+function nnmath:rand/list
+
+tellraw @a {"text":"Done.","color":"gold"}
+tellraw @a {"text":"-------------------------------------","color":"gold"}

--- a/nn_math/data/nnmath/functions/rand/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/exe.mcfunction
@@ -1,0 +1,18 @@
+##by NOPEname
+
+execute if score min nnmath_rand > max nnmath_rand run function nnmath:zz_private/rand/swap_input
+
+scoreboard players add max nnmath_rand 1
+scoreboard players operation range nnmath_rand = max nnmath_rand
+scoreboard players operation range nnmath_rand -= min nnmath_rand
+
+scoreboard players operation tmp0 nnmath_rand = range nnmath_rand
+scoreboard players remove tmp0 nnmath_rand 1
+function nnmath:zz_private/rand/next_int_lcg
+scoreboard players operation out nnmath_rand += min nnmath_rand
+
+###scoreboard players reset tmp0 nnmath_rand
+scoreboard players remove max nnmath_rand 1
+
+
+# tmp0 used in "next_int_lcg"

--- a/nn_math/data/nnmath/functions/rand/help.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/help.mcfunction
@@ -1,0 +1,10 @@
+ ##by NOPEname
+
+tellraw @a {"text":"\n>>Help > rand:","color":"gold"}
+tellraw @a {"text":"-Input: function (name: 'nnmath:rand/seed' ; optional)","color":"gray"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nn_math_rand' , name: 'min')","color":"gray"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nn_math_rand' , name: 'max')","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_rand', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:trig/sin_lt","color":"gray"}
+tellraw @a {"text":"-Methode used: LCG + sine (for a \"more random\" pattern)","color":"gray"}
+tellraw @a {"text":"-Credits: based on the LCG RNG by CloudWolf (https://youtu.be/fzZASMieGn0)","color":"gray"}

--- a/nn_math/data/nnmath/functions/rand/is_installed.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/is_installed.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+time query gametime

--- a/nn_math/data/nnmath/functions/rand/list.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"-math.rand","color":"gray"}

--- a/nn_math/data/nnmath/functions/rand/seed.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/seed.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+summon minecraft:area_effect_cloud ~ ~ ~ {Tags:["uuid"]}
+execute store result score tmp_lcg nnmath_rand run data get entity @e[tag=uuid,limit=1] UUID[0]
+kill @e[tag=uuid]

--- a/nn_math/data/nnmath/functions/rand/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/rand/setup.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_rand dummy
+scoreboard players set 2 nnmath_rand 2
+scoreboard players set lcg nnmath_rand 1103515245
+scoreboard players set 100000000 nnmath_rand 100000000
+
+tellraw @a {"text":"-math.rand installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/setup.mcfunction
@@ -1,0 +1,23 @@
+##by NOPEname
+
+tellraw @a {"text":"\n-------------------------------------","color":"gold"}
+tellraw @a {"text":">>Installing Math Library Pack (by NOPEname).","color":"gold"}
+
+function nnmath:sqrt/setup
+function nnmath:trig/setup
+function nnmath:vec/setup
+function nnmath:rand/setup
+
+tellraw @a {"text":"-------------------------------------"}
+
+function nnalg:setup
+
+tellraw @a {"text":"-------------------------------------"}
+
+gamerule commandBlockOutput false
+tellraw @a {"text":">>Gamerule 'commandBlockOutput' set to 'false'","color":"gray"}
+gamerule logAdminCommands false
+tellraw @a {"text":">>Gamerule 'logAdminCommands' set to 'false'","color":"gray"}
+
+tellraw @a {"text":"Done.","color":"gold"}
+tellraw @a {"text":"-------------------------------------","color":"gold"}

--- a/nn_math/data/nnmath/functions/sqrt/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/sqrt/exe.mcfunction
@@ -1,0 +1,21 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_sqrt
+#		name: 		in
+
+#use:				<this>
+#preserves input: 	yes
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_sqrt
+#		name: 		out
+
+
+scoreboard players operation out nnmath_sqrt = in nnmath_sqrt
+scoreboard players set tmp nnmath_sqrt 1
+
+execute if score out nnmath_sqrt > tmp nnmath_sqrt run function nnmath:zz_private/sqrt/loop

--- a/nn_math/data/nnmath/functions/sqrt/help.mcfunction
+++ b/nn_math/data/nnmath/functions/sqrt/help.mcfunction
@@ -1,0 +1,9 @@
+ ##by NOPEname
+
+tellraw @a {"text":"\n>>Help > sqrt:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_sqrt', name: 'in')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_sqrt', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value, rounded down to integer","color":"gray"}
+tellraw @a {"text":"-Methode used: Babylonian method","color":"gray"}

--- a/nn_math/data/nnmath/functions/sqrt/is_installed.mcfunction
+++ b/nn_math/data/nnmath/functions/sqrt/is_installed.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+time query gametime

--- a/nn_math/data/nnmath/functions/sqrt/list.mcfunction
+++ b/nn_math/data/nnmath/functions/sqrt/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"-math.sqrt","color":"gray"}

--- a/nn_math/data/nnmath/functions/sqrt/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/sqrt/setup.mcfunction
@@ -1,0 +1,6 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_sqrt dummy
+scoreboard players set 2 nnmath_sqrt 2
+
+tellraw @a {"text":"-math.sqrt installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/arcsin/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/arcsin/exe.mcfunction
@@ -1,0 +1,95 @@
+##by NOPEname
+
+# Source: http://mathforum.org/library/drmath/view/54137.html
+# pi/2 - sqrt(1-x) * ( 1.5707288 − 0.2121144 * x + 0.0742610 * x*x - 0.0187293 * x*x*x)
+# deg: (pi/2 -> 0.5)
+# ..-1 -> 1.. !
+
+# x -> x * 1000 input!!!
+
+# >> "0.0187293 * x*x*x": (0.9 | 900 -> 0.013646 | 13646)
+# "a"
+# x * 100
+# * 1872
+# / 10000
+# * (x / 10)   [input scale!]
+# * (x / 10)   [input scale!]
+# / 10000
+#
+# >> "0.0742610 * x*x": (0.9 | 900 -> 0.060150 | 60150)
+# "b"
+# 7426 * x
+# / 100
+# * x
+# / 1000
+#
+# >> "0.2121144 * x": (0.9 | 900 -> 0.1909 | ~190900)
+# "c"
+# 212114 * x
+# / 1000
+#
+# >> Combine: ( ~45410)
+# "d"
+# 1570728 - c
+# + b
+# - a         ( ~1426332)
+# * 100
+# / 3141
+#
+# >>Sqrt: (0.9 | 900 -> 0.3162 | 3162)
+# "s"
+# sqrt( 100000000 - (x * 100000) )
+#
+# >> Calc:
+# 500000   (0.5)
+# - (s * d / 1000)
+# / 1000
+# * 18    (deg)
+
+scoreboard players operation tmp0 nnmath_trig = in nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= 10 nnmath_trig
+execute if score in nnmath_trig matches ..-1 run scoreboard players operation tmp0 nnmath_trig *= -1 nnmath_trig
+
+scoreboard players operation tmp1 nnmath_trig = tmp0 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig *= 100000 nnmath_trig
+scoreboard players set in nnmath_sqrt 100000000
+scoreboard players operation in nnmath_sqrt -= tmp1 nnmath_trig
+function nnmath:sqrt/exe
+
+scoreboard players operation t_in nnmath_trig = tmp0 nnmath_trig
+scoreboard players operation t_in nnmath_trig /= 10 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig = tmp0 nnmath_trig
+scoreboard players operation tmp2 nnmath_trig = tmp0 nnmath_trig
+
+scoreboard players operation tmp0 nnmath_trig *= 100 nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= 1872 nnmath_trig
+scoreboard players operation tmp0 nnmath_trig /= 10000 nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= t_in nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= t_in nnmath_trig
+scoreboard players operation tmp0 nnmath_trig /= 10000 nnmath_trig
+
+scoreboard players operation tmp1 nnmath_trig *= 7426 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig /= 100 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig *= tmp2 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig /= 1000 nnmath_trig
+
+scoreboard players operation tmp2 nnmath_trig *= 212114 nnmath_trig
+scoreboard players operation tmp2 nnmath_trig /= 1000 nnmath_trig
+
+scoreboard players operation tmp1 nnmath_trig += 1570728 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig -= tmp0 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig -= tmp2 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig *= 100 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig /= 3141 nnmath_trig
+
+scoreboard players set out nnmath_trig 500000
+scoreboard players operation out nnmath_sqrt *= tmp1 nnmath_trig
+scoreboard players operation out nnmath_sqrt /= 1000 nnmath_trig
+scoreboard players operation out nnmath_trig -= out nnmath_sqrt
+scoreboard players operation out nnmath_trig /= 1000 nnmath_trig
+scoreboard players operation out nnmath_trig *= 18 nnmath_trig
+
+scoreboard players operation out nnmath_trig /= 10 nnmath_trig
+###tellraw @a [{"text":"out: "},{"score":{"objective":"nnmath_trig","name":"out"}}]
+
+execute if score in nnmath_trig matches ..-1 run scoreboard players operation out nnmath_trig *= -1 nnmath_trig

--- a/nn_math/data/nnmath/functions/trig/arcsin/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/arcsin/help.mcfunction
@@ -1,0 +1,11 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/arcsin","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: range [-1..1] scaled by 100 (example: 90 stands for 0.9 )","color":"gray"}
+tellraw @a {"text":"-Preserves input: -","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: angle in degrees, scaled by 10 (example: set 12 for 1.2° )","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:sqrt","color":"gray"}
+tellraw @a {"text":"-Accuracy: max error: < 1° (scaled: 10)","color":"gray"}
+tellraw @a [{"text":"-Method used: 'pi/2 - sqrt(1-x) * ( 1.5707288 − 0.2121144 * x + 0.0742610 * x*x - 0.0187293 * x*x*x)' [rad -> deg] (","color":"gray"},{"text":"http://mathforum.org/library/drmath/view/54137.html","clickEvent":{"action":"open_url","value":"http://mathforum.org/library/drmath/view/54137.html"}},{"text":")","color":"gray"}]

--- a/nn_math/data/nnmath/functions/trig/arcsin/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/arcsin/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.arcsin","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/arcsin/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/arcsin/setup.mcfunction
@@ -1,0 +1,17 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_trig dummy
+scoreboard players set -1 nnmath_trig -1
+scoreboard players set 100000 nnmath_trig 100000
+scoreboard players set 10000 nnmath_trig 10000
+scoreboard players set 100 nnmath_trig 100
+scoreboard players set 10 nnmath_trig 10
+scoreboard players set 1872 nnmath_trig 1872
+scoreboard players set 7426 nnmath_trig 7426
+scoreboard players set 212114 nnmath_trig 212114
+scoreboard players set 1570728 nnmath_trig 1570728
+scoreboard players set 500000 nnmath_trig 500000
+scoreboard players set 18 nnmath_trig 18
+scoreboard players set 3141 nnmath_trig 3141
+
+tellraw @a {"text":"-math.trig.arcsin installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/arcsin/test.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/arcsin/test.mcfunction
@@ -1,0 +1,618 @@
+##by NOPEname
+
+scoreboard players set in nnmath_trig -100
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+
+
+
+##################################################################
+
+
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}
+
+scoreboard players add in nnmath_trig 1
+function nnmath:trig/arcsin/exe
+tellraw @a {"score":{"objective":"nnmath_trig","name":"out"}}

--- a/nn_math/data/nnmath/functions/trig/cos_bs/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_bs/exe.mcfunction
@@ -1,0 +1,26 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees, scaled by 100		(example: set 100 for 1° )
+
+#use:				<this>
+#dependencies:		<math:trig/sin_bs>
+#preserves input: 	no	(values outside [0..36000] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by 10000		(example: 936 stands for 0.0936 )
+#		accuracy:	max error: 0.0005	(scaled -> 5 )
+
+
+
+scoreboard players operation in nnmath_trig %= 36000 nnmath_trig
+scoreboard players add in nnmath_trig 9000
+function nnmath:trig/sin_bs/exe
+scoreboard players remove in nnmath_trig 9000 

--- a/nn_math/data/nnmath/functions/trig/cos_bs/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_bs/help.mcfunction
@@ -1,0 +1,11 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/cos_bs:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees, scaled by 100 (example: set 100 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..36000] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 10000 (example: 936 stands for 0.0936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:trig/sin_bs","color":"gray"}
+tellraw @a {"text":"-Accuracy: max error: 0.0005	(scaled -> 5 )","color":"gray"}
+tellraw @a [{"text":"-Method used: Bhaskar-Stroethoff (","color":"gray"},{"text":"https://wiki.tcl-lang.org/page/Indian+Math+Bhaskara+%281%29+Sine+formula+and+extensions%2C+history+of+math++#a0ccfcf15f6b7964bb0cc284e2af6981086e2a18a991cfd83a4883c5b5e4ef80","clickEvent":{"action":"open_url","value":"https://wiki.tcl-lang.org/page/Indian+Math+Bhaskara+%281%29+Sine+formula+and+extensions%2C+history+of+math++#a0ccfcf15f6b7964bb0cc284e2af6981086e2a18a991cfd83a4883c5b5e4ef80"}},{"text":")","color":"gray"}]

--- a/nn_math/data/nnmath/functions/trig/cos_bs/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_bs/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.cos_bs","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/cos_et/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_et/exe.mcfunction
@@ -1,0 +1,32 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees, scaled by 10000		(example: set 10000 for 1° )
+
+#use:				<this>
+#dependencies:		<math:trig/sin_et>
+#preserves input: 	no	(values outside [0..3600000] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by 10000		(example: 936 stands for 0.0936 )
+#		accuracy:	
+
+#additional information:
+#		methode used: entity teleportation (/tp ^ ^ ^1) & nbt-data (Pos[], Rotation[])
+#		WARNING: 	Optifine's "Fast Math" will significantly decrease the accuracy of this function!
+#					It is off by default, but can be activated in "Video Settings > Performance".
+#					If players choose to enable "Fast Math", trig.sin_bs will return better results!
+
+
+
+scoreboard players operation in nnmath_trig %= 3600000 nnmath_trig
+scoreboard players add in nnmath_trig 900000
+function nnmath:trig/sin_et/exe
+scoreboard players remove in nnmath_trig 900000 

--- a/nn_math/data/nnmath/functions/trig/cos_et/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_et/help.mcfunction
@@ -1,0 +1,12 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/cos_et:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees, scaled by 10000 (example: set 10000 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..3600000] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 10000 (example: 936 stands for 0.0936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:trig/sin_et","color":"gray"}
+tellraw @a {"text":"-Accuracy: max error: 0.0005	(scaled -> 5 )","color":"gray"}
+tellraw @a {"text":"-Method used: entity teleportation (/tp ^ ^ ^1) & nbt-data (Pos[], Rotation[])"}
+tellraw @a {"text":"-WARNING: Optifine's 'Fast Math' will significantly decrease the accuracy of this function! It is off by default, but can be activated in 'Video Settings > Performance'. If players choose to enable 'Fast Math', trig.cos_bs will return better results!","color":"red"}

--- a/nn_math/data/nnmath/functions/trig/cos_et/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_et/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.cos_et","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/cos_lt/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_lt/exe.mcfunction
@@ -1,0 +1,28 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees	(values outside [0..360] will be wrapped into range)
+
+#use:				<this>
+#dependencies:		<math:trig/sin_lt>
+#preserves input: 	no	(values outside [0..360] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by *1000000000	([0..1] -> [0..1000000000])
+#		accuracy:	best possible result
+
+#additional information:
+#		methode used: lookup table
+
+
+scoreboard players operation in nnmath_trig %= 360 nnmath_trig
+scoreboard players add in nnmath_trig 90
+function nnmath:trig/sin_lt/exe
+scoreboard players remove in nnmath_trig 90

--- a/nn_math/data/nnmath/functions/trig/cos_lt/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_lt/help.mcfunction
@@ -1,0 +1,11 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/cos_lt:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees (example: set 1 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..360] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 1000000000 (example: 936 stands for 0.000000936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:trig/sin_lt","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: lookup table"}

--- a/nn_math/data/nnmath/functions/trig/cos_lt/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/cos_lt/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.cos_lt","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/help.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig-module:","color":"gold"}
+tellraw @a {"text":"-Contains trigonometry functions","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:trig/list' to get a list of all installed trigonometry functions","color":"gray"}
+tellraw @a {"text":"-[sin/cos]_bs -> high accuracy, good performance","color":"gray"}
+tellraw @a {"text":"-[sin/cos]_et -> higher accuracy, medium performance","color":"gray"}
+tellraw @a {"text":"-[sin/cos]_lt -> highest accuracy, best performance, but limited input","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/is_installed.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/is_installed.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+time query gametime

--- a/nn_math/data/nnmath/functions/trig/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/list.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":">math.trig","color":"gray"}
+function nnmath:trig/sin_lt/list
+function nnmath:trig/cos_lt/list
+function nnmath:trig/sin_bs/list
+function nnmath:trig/cos_bs/list
+function nnmath:trig/sin_et/list
+function nnmath:trig/cos_et/list

--- a/nn_math/data/nnmath/functions/trig/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/setup.mcfunction
@@ -1,0 +1,32 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_trig dummy
+scoreboard players set -1 nnmath_trig -1
+scoreboard players set 180 nnmath_trig 180
+scoreboard players set 360 nnmath_trig 360
+
+scoreboard players set 20 nnmath_trig 20
+scoreboard players set 100000 nnmath_trig 100000
+scoreboard players set 10000 nnmath_trig 10000
+scoreboard players set 1000 nnmath_trig 1000
+scoreboard players set 100 nnmath_trig 100
+scoreboard players set 10 nnmath_trig 10
+scoreboard players set 648 nnmath_trig 648
+scoreboard players set 310 nnmath_trig 310
+scoreboard players set 583200 nnmath_trig 583200
+scoreboard players set 18000 nnmath_trig 18000
+scoreboard players set 36000 nnmath_trig 36000
+scoreboard players set 9000 nnmath_trig 9000
+
+scoreboard players set 3600000 nnmath_trig 3600000
+scoreboard players set 900000 nnmath_trig 900000
+
+scoreboard players set 1872 nnmath_trig 1872
+scoreboard players set 7426 nnmath_trig 7426
+scoreboard players set 212114 nnmath_trig 212114
+scoreboard players set 1570728 nnmath_trig 1570728
+scoreboard players set 500000 nnmath_trig 500000
+scoreboard players set 18 nnmath_trig 18
+scoreboard players set 3141 nnmath_trig 3141
+
+tellraw @a {"text":"-math.trig installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_bs/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_bs/exe.mcfunction
@@ -1,0 +1,61 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees, scaled by 100		(example: set 100 for 1° )
+
+#use:				<this>
+#preserves input: 	no	(values outside [0..36000] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by 10000		(example: 936 stands for 0.0936 )
+#		accuracy:	max error: 0.0005	(scaled -> 5 )
+
+#additional information:
+#		methode used: Bhaskar-Stroethoff (https://wiki.tcl-lang.org/page/Indian+Math+Bhaskara+%281%29+Sine+formula+and+extensions%2C+history+of+math++#a0ccfcf15f6b7964bb0cc284e2af6981086e2a18a991cfd83a4883c5b5e4ef80)
+
+
+scoreboard players operation in nnmath_trig %= 36000 nnmath_trig
+scoreboard players operation t_in nnmath_trig = in nnmath_trig
+scoreboard players operation t_in nnmath_trig %= 18000 nnmath_trig
+
+scoreboard players set t_xx nnmath_trig 18000
+scoreboard players operation t_xx nnmath_trig -= t_in nnmath_trig
+scoreboard players operation t_in_sq nnmath_trig = t_in nnmath_trig
+scoreboard players operation t_in_sq nnmath_trig *= t_in nnmath_trig
+scoreboard players operation t_xx_sq nnmath_trig = t_xx nnmath_trig
+scoreboard players operation t_xx_sq nnmath_trig *= t_xx nnmath_trig
+scoreboard players operation t_inxx nnmath_trig = t_in nnmath_trig
+scoreboard players operation t_inxx nnmath_trig *= t_xx nnmath_trig
+
+scoreboard players operation out nnmath_trig = 20 nnmath_trig
+scoreboard players operation out nnmath_trig *= t_inxx nnmath_trig
+scoreboard players set tmp1 nnmath_trig 405000
+scoreboard players operation tmp2 nnmath_trig = t_inxx nnmath_trig
+scoreboard players operation tmp2 nnmath_trig /= 1000 nnmath_trig
+scoreboard players operation tmp1 nnmath_trig -= tmp2 nnmath_trig
+scoreboard players operation out nnmath_trig /= tmp1 nnmath_trig
+
+scoreboard players operation tmp0 nnmath_trig = t_inxx nnmath_trig
+scoreboard players operation tmp0 nnmath_trig /= 10000 nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= 310 nnmath_trig
+scoreboard players operation tmp0 nnmath_trig /= 648 nnmath_trig
+scoreboard players operation out nnmath_trig += tmp0 nnmath_trig
+
+scoreboard players operation t_in_sq nnmath_trig /= 10000 nnmath_trig
+scoreboard players operation t_xx_sq nnmath_trig /= 10000 nnmath_trig
+scoreboard players set tmp0 nnmath_trig 10
+scoreboard players operation tmp0 nnmath_trig *= t_in_sq nnmath_trig
+scoreboard players operation tmp0 nnmath_trig *= t_xx_sq nnmath_trig
+scoreboard players operation tmp0 nnmath_trig /= 583200 nnmath_trig
+scoreboard players operation out nnmath_trig += tmp0 nnmath_trig
+
+execute if score in nnmath_trig matches 18001.. run scoreboard players operation out nnmath_trig *= -1 nnmath_trig
+
+###scoreboard players operation out nnmath_trig /= 10 nnmath_trig

--- a/nn_math/data/nnmath/functions/trig/sin_bs/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_bs/help.mcfunction
@@ -1,0 +1,11 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/sin_bs:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees, scaled by 100 (example: set 100 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..36000] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 10000 (example: 936 stands for 0.0936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: max error: 0.0005	(scaled -> 5 )","color":"gray"}
+tellraw @a [{"text":"-Method used: Bhaskar-Stroethoff (","color":"gray"},{"text":"https://wiki.tcl-lang.org/page/Indian+Math+Bhaskara+%281%29+Sine+formula+and+extensions%2C+history+of+math++#a0ccfcf15f6b7964bb0cc284e2af6981086e2a18a991cfd83a4883c5b5e4ef80","clickEvent":{"action":"open_url","value":"https://wiki.tcl-lang.org/page/Indian+Math+Bhaskara+%281%29+Sine+formula+and+extensions%2C+history+of+math++#a0ccfcf15f6b7964bb0cc284e2af6981086e2a18a991cfd83a4883c5b5e4ef80"}},{"text":")","color":"gray"}]

--- a/nn_math/data/nnmath/functions/trig/sin_bs/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_bs/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.sin_bs","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_bs/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_bs/setup.mcfunction
@@ -1,0 +1,16 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_trig dummy
+scoreboard players set 20 nnmath_trig 20
+scoreboard players set 10000 nnmath_trig 10000
+scoreboard players set 1000 nnmath_trig 1000
+scoreboard players set 10 nnmath_trig 10
+scoreboard players set 648 nnmath_trig 648
+scoreboard players set 310 nnmath_trig 310
+scoreboard players set 583200 nnmath_trig 583200
+scoreboard players set 18000 nnmath_trig 18000
+scoreboard players set 36000 nnmath_trig 36000
+scoreboard players set 9000 nnmath_trig 9000
+scoreboard players set -1 nnmath_trig -1
+
+tellraw @a {"text":"-math.trig.sin_bs installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_et/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_et/exe.mcfunction
@@ -1,0 +1,31 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees, scaled by 10000		(example: set 10000 for 1° )
+
+#use:				<this>
+#preserves input: 	no	(values outside [0..3600000] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by 10000		(example: 936 stands for 0.0936 )
+#		accuracy:	
+
+#additional information:
+#		methode used: entity teleportation (/tp ^ ^ ^1) & nbt-data (Pos[], Rotation[])
+#		WARNING: 	Optifine's "Fast Math" will significantly decrease the accuracy of this function!
+#					It is off by default, but can be activated in "Video Settings > Performance".
+#					If players choose to enable "Fast Math", trig.sin_bs will return better results!
+
+
+scoreboard players operation in nnmath_trig %= 3600000 nnmath_trig
+
+scoreboard players set flag_no_aec nnmath_trig 1
+execute as @e[type=area_effect_cloud,tag=nnmath_trig,limit=1] at @s run function nnmath:zz_private/trig/sin_et/calc
+execute if score flag_no_aec nnmath_trig matches 1 run function nnmath:zz_private/trig/sin_et/no_aec

--- a/nn_math/data/nnmath/functions/trig/sin_et/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_et/help.mcfunction
@@ -1,0 +1,12 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/sin_et:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees, scaled by 10000 (example: set 10000 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..3600000] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 10000 (example: 936 stands for 0.0936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: max error: 0.0005	(scaled -> 5 )","color":"gray"}
+tellraw @a {"text":"-Method used: entity teleportation (/tp ^ ^ ^1) & nbt-data (Pos[], Rotation[])"}
+tellraw @a {"text":"-WARNING: Optifine's 'Fast Math' will significantly decrease the accuracy of this function! It is off by default, but can be activated in 'Video Settings > Performance'. If players choose to enable 'Fast Math', trig.cos_bs will return better results!","color":"red"}

--- a/nn_math/data/nnmath/functions/trig/sin_et/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_et/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.sin_et","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_et/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_et/setup.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_trig dummy
+scoreboard players set 3600000 nnmath_trig 3600000
+scoreboard players set 900000 nnmath_trig 900000
+
+tellraw @a {"text":"-math.trig.sin_et installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_lt/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_lt/exe.mcfunction
@@ -1,0 +1,28 @@
+##by NOPEname
+
+
+#input:
+# 		format:		scoreboard
+#		objective: 	nnmath_trig
+#		name: 		in
+#		format:		angle in degrees	(example: set 1 for 1° )
+
+#use:				<this>
+#preserves input: 	no	(values outside [0..360] will be wrapped into range)
+
+#output:
+#		format: 	scoreboard
+#		objective: 	nnmath_trig
+#		name: 		out
+#		format:		scaled by *1000000000	([0..1] -> [0..1000000000])
+#		accuracy:	best possible result
+
+#additional information:
+#		methode used: lookup table
+
+
+scoreboard players operation in nnmath_trig %= 360 nnmath_trig
+scoreboard players operation tmp nnmath_trig = in nnmath_trig
+scoreboard players operation tmp nnmath_trig %= 180 nnmath_trig
+function nnmath:zz_private/trig/sin_lt/lookup
+execute if score in nnmath_trig matches 181..360 run scoreboard players operation out nnmath_trig *= -1 nnmath_trig

--- a/nn_math/data/nnmath/functions/trig/sin_lt/help.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_lt/help.mcfunction
@@ -1,0 +1,11 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > trig/sin_lt:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_trig', name: 'in')","color":"gray"}
+tellraw @a {"text":"  -> Input format: angle in degrees (example: set 1 for 1° )","color":"gray"}
+tellraw @a {"text":"-Preserves input: no	(values outside [0..360] will be wrapped into range)","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_trig', name: 'out')","color":"gray"}
+tellraw @a {"text":"  -> Output format: scaled by 1000000000 (example: 936 stands for 0.000000936 )","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: lookup table"}

--- a/nn_math/data/nnmath/functions/trig/sin_lt/list.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_lt/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"  -math.trig.sin_lt","color":"gray"}

--- a/nn_math/data/nnmath/functions/trig/sin_lt/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/trig/sin_lt/setup.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_trig dummy
+scoreboard players set -1 nnmath_trig -1
+scoreboard players set 180 nnmath_trig 180
+scoreboard players set 360 nnmath_trig 360
+
+tellraw @a {"text":"-math.trig.sin_lt installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/add/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/add/exe.mcfunction
@@ -1,0 +1,6 @@
+##by NOPEname
+
+scoreboard players operation out.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out.y nnmath_vec = in0.y nnmath_vec
+scoreboard players operation out.x nnmath_vec += in1.x nnmath_vec
+scoreboard players operation out.y nnmath_vec += in1.y nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/2/add/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/add/help.mcfunction
@@ -1,0 +1,10 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2/add:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in1.x', 'in1.y')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out.x', 'out.y')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: in0.(x/y) + in1(x/y)","color":"gray"}
+tellraw @a {"text":"-For 2D-vec subtraction: use vec/2/add with negitive input","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/add/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/add/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/2/add","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/cross/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/cross/exe.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+scoreboard players operation out nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out nnmath_vec *= in1.y nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec = in1.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in0.y nnmath_vec
+scoreboard players operation out nnmath_vec -= tmp0.x nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/2/cross/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/cross/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2/cross:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in1.x', 'in1.y')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: in0.x * in1.y - in1.x * in0.y","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/cross/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/cross/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/2/cross","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/dot/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/dot/exe.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+scoreboard players operation out nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out nnmath_vec *= in1.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec = in0.y nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.y nnmath_vec
+scoreboard players operation out nnmath_vec += tmp0.x nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/2/dot/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/dot/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2/dot:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in1.x', 'in1.y')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: in0.x * in1.x + in0.y * in1.y","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/dot/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/dot/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/2/dot","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/get_length/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/get_length/exe.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+scoreboard players operation tmp0.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in0.x nnmath_vec
+scoreboard players operation in nnmath_sqrt = in0.y nnmath_vec
+scoreboard players operation in nnmath_sqrt *= in0.y nnmath_vec
+scoreboard players operation in nnmath_sqrt += tmp0.x nnmath_vec
+function nnmath:sqrt/exe
+scoreboard players operation out nnmath_vec = out nnmath_sqrt

--- a/nn_math/data/nnmath/functions/vec/2/get_length/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/get_length/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2/get_length:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:sqrt","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: sqrt(x*x + y*y)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/get_length/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/get_length/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/2/get_length","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/help.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2-module:","color":"gold"}
+tellraw @a {"text":"-Contains 2D-vector functions","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:vec/2/list' to get a list of all installed 2D-vector functions","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/list.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+tellraw @a {"text":"  >math.vec/2","color":"gray"}
+function nnmath:vec/2/add/list
+function nnmath:vec/2/cross/list
+function nnmath:vec/2/dot/list
+function nnmath:vec/2/get_length/list
+function nnmath:vec/2/set_length/list

--- a/nn_math/data/nnmath/functions/vec/2/set_length/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/set_length/exe.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+scoreboard players operation out.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out.y nnmath_vec = in0.y nnmath_vec
+scoreboard players operation out.x nnmath_vec *= in_sc nnmath_vec
+scoreboard players operation out.y nnmath_vec *= in_sc nnmath_vec
+function nnmath:vec/2/get_length/exe
+scoreboard players operation out.x nnmath_vec /= out nnmath_vec
+scoreboard players operation out.y nnmath_vec /= out nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/2/set_length/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/set_length/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/2/set_length:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in_sc', 'in0.x', 'in0.y')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out.x', 'out.y')","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:vec/2/get_length, nnmath:sqrt","color":"gray"}
+tellraw @a {"text":"-Accuracy: Might be off by 1 -> scale your values in case they are small","color":"gray"}
+tellraw @a {"text":"-Method used: out = in * in_sc / get_length(in)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/set_length/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/set_length/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/2/set_length","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/2/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/2/setup.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_vec dummy
+
+tellraw @a {"text":"-math.vec/2 installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/add/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/add/exe.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+scoreboard players operation out.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out.y nnmath_vec = in0.y nnmath_vec
+scoreboard players operation out.z nnmath_vec = in0.z nnmath_vec
+scoreboard players operation out.x nnmath_vec += in1.x nnmath_vec
+scoreboard players operation out.y nnmath_vec += in1.y nnmath_vec
+scoreboard players operation out.z nnmath_vec += in1.z nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/3/add/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/add/help.mcfunction
@@ -1,0 +1,10 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3/add:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in0.z', 'in1.x', 'in1.y', 'in1.z')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out.x', 'out.y', 'out.z')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: in0.(x/y/z) + in1(x/y/z)","color":"gray"}
+tellraw @a {"text":"-For 3D-vec subtraction: use vec/3/add with negitive input","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/add/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/add/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/3/add","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/cross/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/cross/exe.mcfunction
@@ -1,0 +1,19 @@
+##by NOPEname
+
+scoreboard players operation tmp0.x nnmath_vec = in0.z nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.y nnmath_vec
+scoreboard players operation out.x nnmath_vec = in0.y nnmath_vec
+scoreboard players operation out.x nnmath_vec *= in1.z nnmath_vec
+scoreboard players operation out.x nnmath_vec -= tmp0.x nnmath_vec
+
+scoreboard players operation tmp0.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.z nnmath_vec
+scoreboard players operation out.y nnmath_vec = in0.z nnmath_vec
+scoreboard players operation out.y nnmath_vec *= in1.x nnmath_vec
+scoreboard players operation out.y nnmath_vec -= tmp0.x nnmath_vec
+
+scoreboard players operation tmp0.x nnmath_vec = in0.y nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.x nnmath_vec
+scoreboard players operation out.z nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out.z nnmath_vec *= in1.y nnmath_vec
+scoreboard players operation out.z nnmath_vec -= tmp0.x nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/3/cross/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/cross/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3/cross:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in0.z', 'in1.x', 'in1.y', 'in1.z')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out.x', 'out.y', 'out.z')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: scoreboard operation (+=, *=)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/cross/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/cross/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/3/cross","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/dot/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/dot/exe.mcfunction
@@ -1,0 +1,10 @@
+##by NOPEname
+
+scoreboard players operation out nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out nnmath_vec *= in1.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec = in0.y nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.y nnmath_vec
+scoreboard players operation out nnmath_vec += tmp0.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec = in0.z nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in1.z nnmath_vec
+scoreboard players operation out nnmath_vec += tmp0.x nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/3/dot/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/dot/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3/dot:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in0.z', 'in1.x', 'in1.y', 'in1.z')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: -","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: scoreboard players operation (+=, *=)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/dot/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/dot/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/3/dot","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/get_length/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/get_length/exe.mcfunction
@@ -1,0 +1,12 @@
+##by NOPEname
+
+scoreboard players operation tmp0.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in0.x nnmath_vec
+scoreboard players operation in nnmath_sqrt = in0.y nnmath_vec
+scoreboard players operation in nnmath_sqrt *= in0.y nnmath_vec
+scoreboard players operation in nnmath_sqrt += tmp0.x nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec = in0.z nnmath_vec
+scoreboard players operation tmp0.x nnmath_vec *= in0.z nnmath_vec
+scoreboard players operation in nnmath_sqrt += tmp0.x nnmath_vec
+function nnmath:sqrt/exe
+scoreboard players operation out nnmath_vec = out nnmath_sqrt

--- a/nn_math/data/nnmath/functions/vec/3/get_length/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/get_length/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3/get_length:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in0.x', 'in0.y', 'in0.z')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out')","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:sqrt","color":"gray"}
+tellraw @a {"text":"-Accuracy: Exact value","color":"gray"}
+tellraw @a {"text":"-Method used: sqrt(x*x + y*y + z*z)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/get_length/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/get_length/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/3/get_length","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/help.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3-module:","color":"gold"}
+tellraw @a {"text":"-Contains 3D-vector functions","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:vec/3/list' to get a list of all installed 3D-vector functions","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/list.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+tellraw @a {"text":"  >math.vec/3","color":"gray"}
+function nnmath:vec/3/add/list
+function nnmath:vec/3/cross/list
+function nnmath:vec/3/dot/list
+function nnmath:vec/3/get_length/list
+function nnmath:vec/3/set_length/list

--- a/nn_math/data/nnmath/functions/vec/3/set_length/exe.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/set_length/exe.mcfunction
@@ -1,0 +1,12 @@
+##by NOPEname
+
+scoreboard players operation out.x nnmath_vec = in0.x nnmath_vec
+scoreboard players operation out.y nnmath_vec = in0.y nnmath_vec
+scoreboard players operation out.z nnmath_vec = in0.z nnmath_vec
+scoreboard players operation out.x nnmath_vec *= in_sc nnmath_vec
+scoreboard players operation out.y nnmath_vec *= in_sc nnmath_vec
+scoreboard players operation out.z nnmath_vec *= in_sc nnmath_vec
+function nnmath:vec/3/get_length/exe
+scoreboard players operation out.x nnmath_vec /= out nnmath_vec
+scoreboard players operation out.y nnmath_vec /= out nnmath_vec
+scoreboard players operation out.z nnmath_vec /= out nnmath_vec

--- a/nn_math/data/nnmath/functions/vec/3/set_length/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/set_length/help.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec/3/set_length:","color":"gold"}
+tellraw @a {"text":"-Input: scoreboard (obj: 'nnmath_vec', name: 'in_sc', 'in0.x', 'in0.y', 'in0.z')","color":"gray"}
+tellraw @a {"text":"-Preserves input: yes","color":"gray"}
+tellraw @a {"text":"-Output: scoreboard (obj: 'nnmath_vec', name: 'out.x', 'out.y', 'out.z')","color":"gray"}
+tellraw @a {"text":"-Dependencies: nnmath:vec/2/get_length, nnmath:sqrt","color":"gray"}
+tellraw @a {"text":"-Accuracy: Might be off by 1 -> scale your values in case they are small","color":"gray"}
+tellraw @a {"text":"-Method used: out = in * in_sc / get_length(in)","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/set_length/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/set_length/list.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+tellraw @a {"text":"    -math.vec/3/set_length","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/3/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/3/setup.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_vec dummy
+
+tellraw @a {"text":"-math.vec/3 installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/help.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/help.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+tellraw @a {"text":"\n>>Help > vec-module:","color":"gold"}
+tellraw @a {"text":"-Contains vector functions","color":"gray"}
+tellraw @a {"text":"-Run '/function nnmath:vec/list' to get a list of all installed vector functions","color":"gray"}
+tellraw @a {"text":"-'vec/2/...' -> 2D","color":"gray"}
+tellraw @a {"text":"-'vec/3/...' -> 3D","color":"gray"}

--- a/nn_math/data/nnmath/functions/vec/is_installed.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/is_installed.mcfunction
@@ -1,0 +1,3 @@
+##by NOPEname
+
+time query gametime

--- a/nn_math/data/nnmath/functions/vec/list.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/list.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+tellraw @a {"text":">math.vec","color":"gray"}
+function nnmath:vec/2/list
+function nnmath:vec/3/list

--- a/nn_math/data/nnmath/functions/vec/setup.mcfunction
+++ b/nn_math/data/nnmath/functions/vec/setup.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+scoreboard objectives add nnmath_vec dummy
+
+tellraw @a {"text":"-math.vec installed","color":"gray"}

--- a/nn_math/data/nnmath/functions/zz_private/rand/next_int_lcg.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/rand/next_int_lcg.mcfunction
@@ -1,0 +1,16 @@
+##by NOPEname
+
+#lcg
+scoreboard players operation tmp_lcg nnmath_rand *= lcg nnmath_rand
+scoreboard players add tmp_lcg nnmath_rand 12345
+function nnmath:zz_private/rand/sin
+scoreboard players operation out nnmath_rand = tmp_lcg nnmath_rand
+
+
+
+#range
+scoreboard players operation tmp1 nnmath_rand = out nnmath_rand
+scoreboard players operation out nnmath_rand %= range nnmath_rand
+scoreboard players operation tmp1 nnmath_rand -= out nnmath_rand
+scoreboard players operation tmp1 nnmath_rand += tmp0 nnmath_rand
+execute if score tmp1 nnmath_rand matches ..-1 run function nnmath:zz_private/rand/next_int_lcg

--- a/nn_math/data/nnmath/functions/zz_private/rand/sin.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/rand/sin.mcfunction
@@ -1,0 +1,6 @@
+##by NOPEname
+
+scoreboard players operation in nnmath_trig = tmp_lcg nnmath_rand
+function nnmath:trig/sin_lt/exe
+scoreboard players operation out nnmath_trig %= 100000000 nnmath_rand
+scoreboard players operation tmp_lcg nnmath_rand += out nnmath_trig

--- a/nn_math/data/nnmath/functions/zz_private/rand/swap_input.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/rand/swap_input.mcfunction
@@ -1,0 +1,5 @@
+##by NOPEname
+
+scoreboard players operation tmp nnmath_rand = min nnmath_rand
+scoreboard players operation min nnmath_rand = max nnmath_rand
+scoreboard players operation max nnmath_rand = tmp nnmath_rand

--- a/nn_math/data/nnmath/functions/zz_private/sqrt/loop.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/sqrt/loop.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+scoreboard players operation out nnmath_sqrt += tmp nnmath_sqrt
+scoreboard players operation out nnmath_sqrt /= 2 nnmath_sqrt
+
+scoreboard players operation tmp nnmath_sqrt = in nnmath_sqrt
+scoreboard players operation tmp nnmath_sqrt /= out nnmath_sqrt
+
+execute if score out nnmath_sqrt > tmp nnmath_sqrt run function nnmath:zz_private/sqrt/loop

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_et/calc.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_et/calc.mcfunction
@@ -1,0 +1,10 @@
+##by NOPEname
+
+scoreboard players set flag_no_aec nnmath_trig 0
+
+tp @s 0.0 0.0 0.0 
+execute store result score out nnmath_trig run data get entity @s Pos[0] 10000
+execute store result entity @s Rotation[0] float 0.0001 run scoreboard players get in nnmath_trig
+execute at @s run tp @s ^ ^ ^100
+execute store result score tmp0 nnmath_trig run data get entity @s Pos[0] 10000
+scoreboard players operation out nnmath_trig -= tmp0 nnmath_trig

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_et/no_aec.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_et/no_aec.mcfunction
@@ -1,0 +1,4 @@
+##by NOPEname
+
+summon area_effect_cloud 0.0 0.0 0.0 {Duration:1,Tags:[nnmath_trig]}
+execute as @e[type=area_effect_cloud,tag=nnmath_trig,limit=1] run function nnmath:zz_private/trig/sin_et/calc

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/0.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/0.mcfunction
@@ -1,0 +1,9 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 0 run scoreboard players set out nnmath_trig 0
+execute if score tmp nnmath_trig matches 1 run scoreboard players set out nnmath_trig 17452406
+execute if score tmp nnmath_trig matches 2 run scoreboard players set out nnmath_trig 34899496
+execute if score tmp nnmath_trig matches 3 run scoreboard players set out nnmath_trig 52335956
+execute if score tmp nnmath_trig matches 4 run scoreboard players set out nnmath_trig 69756473
+execute if score tmp nnmath_trig matches 5 run scoreboard players set out nnmath_trig 87155742
+execute if score tmp nnmath_trig matches 6 run scoreboard players set out nnmath_trig 104528463

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/103.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/103.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 103 run scoreboard players set out nnmath_trig 974370064
+execute if score tmp nnmath_trig matches 104 run scoreboard players set out nnmath_trig 970295726
+execute if score tmp nnmath_trig matches 105 run scoreboard players set out nnmath_trig 965925826
+execute if score tmp nnmath_trig matches 106 run scoreboard players set out nnmath_trig 961261695
+execute if score tmp nnmath_trig matches 107 run scoreboard players set out nnmath_trig 956304755
+execute if score tmp nnmath_trig matches 108 run scoreboard players set out nnmath_trig 951056516

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/109.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/109.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 109 run scoreboard players set out nnmath_trig 945518575
+execute if score tmp nnmath_trig matches 110 run scoreboard players set out nnmath_trig 939692620
+execute if score tmp nnmath_trig matches 111 run scoreboard players set out nnmath_trig 933580426
+execute if score tmp nnmath_trig matches 112 run scoreboard players set out nnmath_trig 927183854
+execute if score tmp nnmath_trig matches 113 run scoreboard players set out nnmath_trig 920504853
+execute if score tmp nnmath_trig matches 114 run scoreboard players set out nnmath_trig 913545457

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/115.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/115.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 115 run scoreboard players set out nnmath_trig 906307787
+execute if score tmp nnmath_trig matches 116 run scoreboard players set out nnmath_trig 898794046
+execute if score tmp nnmath_trig matches 117 run scoreboard players set out nnmath_trig 891006524
+execute if score tmp nnmath_trig matches 118 run scoreboard players set out nnmath_trig 882947592
+execute if score tmp nnmath_trig matches 119 run scoreboard players set out nnmath_trig 874619707
+execute if score tmp nnmath_trig matches 120 run scoreboard players set out nnmath_trig 866025403

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/121.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/121.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 121 run scoreboard players set out nnmath_trig 857167300
+execute if score tmp nnmath_trig matches 122 run scoreboard players set out nnmath_trig 848048096
+execute if score tmp nnmath_trig matches 123 run scoreboard players set out nnmath_trig 838670567
+execute if score tmp nnmath_trig matches 124 run scoreboard players set out nnmath_trig 829037572
+execute if score tmp nnmath_trig matches 125 run scoreboard players set out nnmath_trig 819152044
+execute if score tmp nnmath_trig matches 126 run scoreboard players set out nnmath_trig 809016994

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/127.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/127.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 127 run scoreboard players set out nnmath_trig 798635510
+execute if score tmp nnmath_trig matches 128 run scoreboard players set out nnmath_trig 788010753
+execute if score tmp nnmath_trig matches 129 run scoreboard players set out nnmath_trig 777145961
+execute if score tmp nnmath_trig matches 130 run scoreboard players set out nnmath_trig 766044443
+execute if score tmp nnmath_trig matches 131 run scoreboard players set out nnmath_trig 754709580
+execute if score tmp nnmath_trig matches 132 run scoreboard players set out nnmath_trig 743144825

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/13.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/13.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 13 run scoreboard players set out nnmath_trig 224951054
+execute if score tmp nnmath_trig matches 14 run scoreboard players set out nnmath_trig 241921895
+execute if score tmp nnmath_trig matches 15 run scoreboard players set out nnmath_trig 258819045
+execute if score tmp nnmath_trig matches 16 run scoreboard players set out nnmath_trig 275637355
+execute if score tmp nnmath_trig matches 17 run scoreboard players set out nnmath_trig 292371704
+execute if score tmp nnmath_trig matches 18 run scoreboard players set out nnmath_trig 309016994

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/133.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/133.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 133 run scoreboard players set out nnmath_trig 731353701
+execute if score tmp nnmath_trig matches 134 run scoreboard players set out nnmath_trig 719339800
+execute if score tmp nnmath_trig matches 135 run scoreboard players set out nnmath_trig 707106781
+execute if score tmp nnmath_trig matches 136 run scoreboard players set out nnmath_trig 694658370
+execute if score tmp nnmath_trig matches 137 run scoreboard players set out nnmath_trig 681998360
+execute if score tmp nnmath_trig matches 138 run scoreboard players set out nnmath_trig 669130606

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/139.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/139.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 139 run scoreboard players set out nnmath_trig 656059028
+execute if score tmp nnmath_trig matches 140 run scoreboard players set out nnmath_trig 642787609
+execute if score tmp nnmath_trig matches 141 run scoreboard players set out nnmath_trig 629320391
+execute if score tmp nnmath_trig matches 142 run scoreboard players set out nnmath_trig 615661475
+execute if score tmp nnmath_trig matches 143 run scoreboard players set out nnmath_trig 601815023
+execute if score tmp nnmath_trig matches 144 run scoreboard players set out nnmath_trig 587785252

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/145.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/145.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 145 run scoreboard players set out nnmath_trig 573576436
+execute if score tmp nnmath_trig matches 146 run scoreboard players set out nnmath_trig 559192903
+execute if score tmp nnmath_trig matches 147 run scoreboard players set out nnmath_trig 544639035
+execute if score tmp nnmath_trig matches 148 run scoreboard players set out nnmath_trig 529919264
+execute if score tmp nnmath_trig matches 149 run scoreboard players set out nnmath_trig 515038074
+execute if score tmp nnmath_trig matches 150 run scoreboard players set out nnmath_trig 499999999

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/151.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/151.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 151 run scoreboard players set out nnmath_trig 484809620
+execute if score tmp nnmath_trig matches 152 run scoreboard players set out nnmath_trig 469471562
+execute if score tmp nnmath_trig matches 153 run scoreboard players set out nnmath_trig 453990499
+execute if score tmp nnmath_trig matches 154 run scoreboard players set out nnmath_trig 438371146
+execute if score tmp nnmath_trig matches 155 run scoreboard players set out nnmath_trig 422618261
+execute if score tmp nnmath_trig matches 156 run scoreboard players set out nnmath_trig 406736643

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/157.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/157.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 157 run scoreboard players set out nnmath_trig 390731128
+execute if score tmp nnmath_trig matches 158 run scoreboard players set out nnmath_trig 374606593
+execute if score tmp nnmath_trig matches 159 run scoreboard players set out nnmath_trig 358367949
+execute if score tmp nnmath_trig matches 160 run scoreboard players set out nnmath_trig 342020143
+execute if score tmp nnmath_trig matches 161 run scoreboard players set out nnmath_trig 325568154
+execute if score tmp nnmath_trig matches 162 run scoreboard players set out nnmath_trig 309016994

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/163.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/163.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 163 run scoreboard players set out nnmath_trig 292371704
+execute if score tmp nnmath_trig matches 164 run scoreboard players set out nnmath_trig 275637355
+execute if score tmp nnmath_trig matches 165 run scoreboard players set out nnmath_trig 258819045
+execute if score tmp nnmath_trig matches 166 run scoreboard players set out nnmath_trig 241921895
+execute if score tmp nnmath_trig matches 167 run scoreboard players set out nnmath_trig 224951054
+execute if score tmp nnmath_trig matches 168 run scoreboard players set out nnmath_trig 207911690

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/169.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/169.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 169 run scoreboard players set out nnmath_trig 190808995
+execute if score tmp nnmath_trig matches 170 run scoreboard players set out nnmath_trig 173648177
+execute if score tmp nnmath_trig matches 171 run scoreboard players set out nnmath_trig 156434465
+execute if score tmp nnmath_trig matches 172 run scoreboard players set out nnmath_trig 139173100
+execute if score tmp nnmath_trig matches 173 run scoreboard players set out nnmath_trig 121869343
+execute if score tmp nnmath_trig matches 174 run scoreboard players set out nnmath_trig 104528463

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/175.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/175.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 175 run scoreboard players set out nnmath_trig 87155742
+execute if score tmp nnmath_trig matches 176 run scoreboard players set out nnmath_trig 69756473
+execute if score tmp nnmath_trig matches 177 run scoreboard players set out nnmath_trig 52335956
+execute if score tmp nnmath_trig matches 178 run scoreboard players set out nnmath_trig 34899496
+execute if score tmp nnmath_trig matches 179 run scoreboard players set out nnmath_trig 17452406
+execute if score tmp nnmath_trig matches 180 run scoreboard players set out nnmath_trig 0

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/19.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/19.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 19 run scoreboard players set out nnmath_trig 325568154
+execute if score tmp nnmath_trig matches 20 run scoreboard players set out nnmath_trig 342020143
+execute if score tmp nnmath_trig matches 21 run scoreboard players set out nnmath_trig 358367949
+execute if score tmp nnmath_trig matches 22 run scoreboard players set out nnmath_trig 374606593
+execute if score tmp nnmath_trig matches 23 run scoreboard players set out nnmath_trig 390731128
+execute if score tmp nnmath_trig matches 24 run scoreboard players set out nnmath_trig 406736643

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/25.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/25.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 25 run scoreboard players set out nnmath_trig 422618261
+execute if score tmp nnmath_trig matches 26 run scoreboard players set out nnmath_trig 438371146
+execute if score tmp nnmath_trig matches 27 run scoreboard players set out nnmath_trig 453990499
+execute if score tmp nnmath_trig matches 28 run scoreboard players set out nnmath_trig 469471562
+execute if score tmp nnmath_trig matches 29 run scoreboard players set out nnmath_trig 484809620
+execute if score tmp nnmath_trig matches 30 run scoreboard players set out nnmath_trig 499999999

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/31.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/31.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 31 run scoreboard players set out nnmath_trig 515038074
+execute if score tmp nnmath_trig matches 32 run scoreboard players set out nnmath_trig 529919264
+execute if score tmp nnmath_trig matches 33 run scoreboard players set out nnmath_trig 544639035
+execute if score tmp nnmath_trig matches 34 run scoreboard players set out nnmath_trig 559192903
+execute if score tmp nnmath_trig matches 35 run scoreboard players set out nnmath_trig 573576436
+execute if score tmp nnmath_trig matches 36 run scoreboard players set out nnmath_trig 587785252

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/37.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/37.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 37 run scoreboard players set out nnmath_trig 601815023
+execute if score tmp nnmath_trig matches 38 run scoreboard players set out nnmath_trig 615661475
+execute if score tmp nnmath_trig matches 39 run scoreboard players set out nnmath_trig 629320391
+execute if score tmp nnmath_trig matches 40 run scoreboard players set out nnmath_trig 642787609
+execute if score tmp nnmath_trig matches 41 run scoreboard players set out nnmath_trig 656059028
+execute if score tmp nnmath_trig matches 42 run scoreboard players set out nnmath_trig 669130606

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/43.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/43.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 43 run scoreboard players set out nnmath_trig 681998360
+execute if score tmp nnmath_trig matches 44 run scoreboard players set out nnmath_trig 694658370
+execute if score tmp nnmath_trig matches 45 run scoreboard players set out nnmath_trig 707106781
+execute if score tmp nnmath_trig matches 46 run scoreboard players set out nnmath_trig 719339800
+execute if score tmp nnmath_trig matches 47 run scoreboard players set out nnmath_trig 731353701
+execute if score tmp nnmath_trig matches 48 run scoreboard players set out nnmath_trig 743144825

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/49.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/49.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 49 run scoreboard players set out nnmath_trig 754709580
+execute if score tmp nnmath_trig matches 50 run scoreboard players set out nnmath_trig 766044443
+execute if score tmp nnmath_trig matches 51 run scoreboard players set out nnmath_trig 777145961
+execute if score tmp nnmath_trig matches 52 run scoreboard players set out nnmath_trig 788010753
+execute if score tmp nnmath_trig matches 53 run scoreboard players set out nnmath_trig 798635510
+execute if score tmp nnmath_trig matches 54 run scoreboard players set out nnmath_trig 809016994

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/55.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/55.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 55 run scoreboard players set out nnmath_trig 819152044
+execute if score tmp nnmath_trig matches 56 run scoreboard players set out nnmath_trig 829037572
+execute if score tmp nnmath_trig matches 57 run scoreboard players set out nnmath_trig 838670567
+execute if score tmp nnmath_trig matches 58 run scoreboard players set out nnmath_trig 848048096
+execute if score tmp nnmath_trig matches 59 run scoreboard players set out nnmath_trig 857167300
+execute if score tmp nnmath_trig matches 60 run scoreboard players set out nnmath_trig 866025403

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/61.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/61.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 61 run scoreboard players set out nnmath_trig 874619707
+execute if score tmp nnmath_trig matches 62 run scoreboard players set out nnmath_trig 882947592
+execute if score tmp nnmath_trig matches 63 run scoreboard players set out nnmath_trig 891006524
+execute if score tmp nnmath_trig matches 64 run scoreboard players set out nnmath_trig 898794046
+execute if score tmp nnmath_trig matches 65 run scoreboard players set out nnmath_trig 906307787
+execute if score tmp nnmath_trig matches 66 run scoreboard players set out nnmath_trig 913545457

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/67.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/67.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 67 run scoreboard players set out nnmath_trig 920504853
+execute if score tmp nnmath_trig matches 68 run scoreboard players set out nnmath_trig 927183854
+execute if score tmp nnmath_trig matches 69 run scoreboard players set out nnmath_trig 933580426
+execute if score tmp nnmath_trig matches 70 run scoreboard players set out nnmath_trig 939692620
+execute if score tmp nnmath_trig matches 71 run scoreboard players set out nnmath_trig 945518575
+execute if score tmp nnmath_trig matches 72 run scoreboard players set out nnmath_trig 951056516

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/7.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/7.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 7 run scoreboard players set out nnmath_trig 121869343
+execute if score tmp nnmath_trig matches 8 run scoreboard players set out nnmath_trig 139173100
+execute if score tmp nnmath_trig matches 9 run scoreboard players set out nnmath_trig 156434465
+execute if score tmp nnmath_trig matches 10 run scoreboard players set out nnmath_trig 173648177
+execute if score tmp nnmath_trig matches 11 run scoreboard players set out nnmath_trig 190808995
+execute if score tmp nnmath_trig matches 12 run scoreboard players set out nnmath_trig 207911690

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/73.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/73.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 73 run scoreboard players set out nnmath_trig 956304755
+execute if score tmp nnmath_trig matches 74 run scoreboard players set out nnmath_trig 961261695
+execute if score tmp nnmath_trig matches 75 run scoreboard players set out nnmath_trig 965925826
+execute if score tmp nnmath_trig matches 76 run scoreboard players set out nnmath_trig 970295726
+execute if score tmp nnmath_trig matches 77 run scoreboard players set out nnmath_trig 974370064
+execute if score tmp nnmath_trig matches 78 run scoreboard players set out nnmath_trig 978147600

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/79.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/79.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 79 run scoreboard players set out nnmath_trig 981627183
+execute if score tmp nnmath_trig matches 80 run scoreboard players set out nnmath_trig 984807753
+execute if score tmp nnmath_trig matches 81 run scoreboard players set out nnmath_trig 987688340
+execute if score tmp nnmath_trig matches 82 run scoreboard players set out nnmath_trig 990268068
+execute if score tmp nnmath_trig matches 83 run scoreboard players set out nnmath_trig 992546151
+execute if score tmp nnmath_trig matches 84 run scoreboard players set out nnmath_trig 994521895

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/85.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/85.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 85 run scoreboard players set out nnmath_trig 996194698
+execute if score tmp nnmath_trig matches 86 run scoreboard players set out nnmath_trig 997564050
+execute if score tmp nnmath_trig matches 87 run scoreboard players set out nnmath_trig 998629534
+execute if score tmp nnmath_trig matches 88 run scoreboard players set out nnmath_trig 999390827
+execute if score tmp nnmath_trig matches 89 run scoreboard players set out nnmath_trig 999847695
+execute if score tmp nnmath_trig matches 90 run scoreboard players set out nnmath_trig 1000000000

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/91.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/91.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 91 run scoreboard players set out nnmath_trig 999847695
+execute if score tmp nnmath_trig matches 92 run scoreboard players set out nnmath_trig 999390827
+execute if score tmp nnmath_trig matches 93 run scoreboard players set out nnmath_trig 998629534
+execute if score tmp nnmath_trig matches 94 run scoreboard players set out nnmath_trig 997564050
+execute if score tmp nnmath_trig matches 95 run scoreboard players set out nnmath_trig 996194698
+execute if score tmp nnmath_trig matches 96 run scoreboard players set out nnmath_trig 994521895

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/97.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/97.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 97 run scoreboard players set out nnmath_trig 992546151
+execute if score tmp nnmath_trig matches 98 run scoreboard players set out nnmath_trig 990268068
+execute if score tmp nnmath_trig matches 99 run scoreboard players set out nnmath_trig 987688340
+execute if score tmp nnmath_trig matches 100 run scoreboard players set out nnmath_trig 984807753
+execute if score tmp nnmath_trig matches 101 run scoreboard players set out nnmath_trig 981627183
+execute if score tmp nnmath_trig matches 102 run scoreboard players set out nnmath_trig 978147600

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_0.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_0.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 0..6 run function nnmath:zz_private/trig/sin_lt/0
+execute if score tmp nnmath_trig matches 7..12 run function nnmath:zz_private/trig/sin_lt/7
+execute if score tmp nnmath_trig matches 13..18 run function nnmath:zz_private/trig/sin_lt/13
+execute if score tmp nnmath_trig matches 19..24 run function nnmath:zz_private/trig/sin_lt/19
+execute if score tmp nnmath_trig matches 25..30 run function nnmath:zz_private/trig/sin_lt/25

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_121.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_121.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 121..126 run function nnmath:zz_private/trig/sin_lt/121
+execute if score tmp nnmath_trig matches 127..132 run function nnmath:zz_private/trig/sin_lt/127
+execute if score tmp nnmath_trig matches 133..138 run function nnmath:zz_private/trig/sin_lt/133
+execute if score tmp nnmath_trig matches 139..144 run function nnmath:zz_private/trig/sin_lt/139
+execute if score tmp nnmath_trig matches 145..150 run function nnmath:zz_private/trig/sin_lt/145

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_151.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_151.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 151..156 run function nnmath:zz_private/trig/sin_lt/151
+execute if score tmp nnmath_trig matches 157..162 run function nnmath:zz_private/trig/sin_lt/157
+execute if score tmp nnmath_trig matches 163..168 run function nnmath:zz_private/trig/sin_lt/163
+execute if score tmp nnmath_trig matches 169..174 run function nnmath:zz_private/trig/sin_lt/169
+execute if score tmp nnmath_trig matches 175..180 run function nnmath:zz_private/trig/sin_lt/175

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_31.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_31.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 31..36 run function nnmath:zz_private/trig/sin_lt/31
+execute if score tmp nnmath_trig matches 37..42 run function nnmath:zz_private/trig/sin_lt/37
+execute if score tmp nnmath_trig matches 43..48 run function nnmath:zz_private/trig/sin_lt/43
+execute if score tmp nnmath_trig matches 49..54 run function nnmath:zz_private/trig/sin_lt/49
+execute if score tmp nnmath_trig matches 55..60 run function nnmath:zz_private/trig/sin_lt/55

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_61.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_61.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 61..66 run function nnmath:zz_private/trig/sin_lt/61
+execute if score tmp nnmath_trig matches 67..72 run function nnmath:zz_private/trig/sin_lt/67
+execute if score tmp nnmath_trig matches 73..78 run function nnmath:zz_private/trig/sin_lt/73
+execute if score tmp nnmath_trig matches 79..84 run function nnmath:zz_private/trig/sin_lt/79
+execute if score tmp nnmath_trig matches 85..90 run function nnmath:zz_private/trig/sin_lt/85

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_91.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/a_91.mcfunction
@@ -1,0 +1,7 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 91..96 run function nnmath:zz_private/trig/sin_lt/91
+execute if score tmp nnmath_trig matches 97..102 run function nnmath:zz_private/trig/sin_lt/97
+execute if score tmp nnmath_trig matches 103..108 run function nnmath:zz_private/trig/sin_lt/103
+execute if score tmp nnmath_trig matches 109..114 run function nnmath:zz_private/trig/sin_lt/109
+execute if score tmp nnmath_trig matches 115..120 run function nnmath:zz_private/trig/sin_lt/115

--- a/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/lookup.mcfunction
+++ b/nn_math/data/nnmath/functions/zz_private/trig/sin_lt/lookup.mcfunction
@@ -1,0 +1,8 @@
+##by NOPEname
+
+execute if score tmp nnmath_trig matches 0..30 run function nnmath:zz_private/trig/sin_lt/a_0
+execute if score tmp nnmath_trig matches 31..60 run function nnmath:zz_private/trig/sin_lt/a_31
+execute if score tmp nnmath_trig matches 61..90 run function nnmath:zz_private/trig/sin_lt/a_61
+execute if score tmp nnmath_trig matches 91..120 run function nnmath:zz_private/trig/sin_lt/a_91
+execute if score tmp nnmath_trig matches 121..150 run function nnmath:zz_private/trig/sin_lt/a_121
+execute if score tmp nnmath_trig matches 151..180 run function nnmath:zz_private/trig/sin_lt/a_151

--- a/nn_math/pack.mcmeta
+++ b/nn_math/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+   "pack":{
+      "pack_format":3,
+      "description":"Math datapack/library by NOPEname"
+   }
+}


### PR DESCRIPTION
Crafting recipes added:
- Warping Obsidian to Crying Obsidian
- Crafting Cherry Wood into Cherry Planks
- Mini Fridge Mixing Lava Buckets & Ice into Obsidian

Tags modified:
- Added Cobbled Soul Sandstone blocks to Soul Speed tag

Datapacks added:
- katy-origins
- [nnmath](https://github.com/NOPEname/nn_math/tree/master)

`katy-origins` contains `katymath`, which is a simple math library that depends on `nnmath` that implements a 2d matrix multiplication function (used for change of basis operations on vectors), and `katyforces` which adds a function that can add a certain amount of force based on a scoreboard variable. `katy-origins/katyorigins` contains Origins powers for tracking the player's input direction and horizontal velocity. It also has some work in progress stuff for telegraphed attacks.